### PR TITLE
Upgrade json for CVE-2020-10663

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
   specs:
     diff-lcs (1.2.5)
     docile (1.1.5)
-    json (2.0.2)
+    json (2.5.1)
     rake (12.3.3)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)

--- a/lib/queue_simple/version.rb
+++ b/lib/queue_simple/version.rb
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 module QueueSimple
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Upgrade `json` gem for [CVE-2020-10663](https://github.com/advisories/GHSA-jphg-qwrw-7w9g)